### PR TITLE
Fixed an issue with case sensitivity

### DIFF
--- a/.comments/..comment
+++ b/.comments/..comment
@@ -1,0 +1,1 @@
+The root directory of the project

--- a/.comments/src.comment
+++ b/.comments/src.comment
@@ -1,1 +1,1 @@
-JS files. 
+Where all of the functionality lives

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 npm-debug.log
-.jshintrc
-.vscode/
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example:
 
 Output:
 
-    "Another comment" was applied to "someDir" succesfully.
+    "Another comment" was applied to "someDir" successfully.
 
     ./           What a great utility!
     ../
@@ -97,7 +97,7 @@ Example:
 
 Output:
 
-    someDir comment was deleted succesfully.
+    someDir comment was deleted successfully.
 
     ./           What a great utility!
     ../

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "true-case-path": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
+      "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "c",
   "description": "Set and remove comments from files and directories, and view them from the command line.",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "homepage": "https://github.com/rumpl/c",
   "author": {
     "name": "Djordje Lukic",
@@ -33,7 +33,8 @@
     "node": "~12.16.2"
   },
   "dependencies": {
-    "colors": "1.4.0"
+    "colors": "1.4.0",
+    "true-case-path": "^2.2.1"
   },
   "devDependencies": {},
   "keywords": [

--- a/src/commands.js
+++ b/src/commands.js
@@ -68,31 +68,29 @@ commands.filteredList = function (dir) {
   helpers.printOnlyComments(files, comments);
 };
 
-/** Adds or overwrites a comment to a file.
- * @param {String} file The name of the file to add a relevant `.comment`.
+/** Adds a comment to a file or directory.
+ * @param {String} node The name of the node to add a relevant `.comment`.
  * @param {String} comment The comment to be written.
  */
-commands.set = function (file, comment) {
+commands.set = function (node, comment) {
   //Checks if the file is invalid
-  if (!fs.existsSync(file)) {
+  if (!fs.existsSync(node)) {
     console.error("Please specify a valid directory or file.");
     return;
   }
 
-  if (file != "./" && file != "../" && file != "." && file != "..") {
-    const pathUpTo = path.resolve("./");
-    const trueFile = trueCasePathSync(file, pathUpTo);
-    file = trueFile.replace(pathUpTo, "").replace("/", "");
-    file = trueFile.replace(pathUpTo, "").replace("\\", "");
+  //If 'node' is valid and has characters, ensure it is case correct
+  if (node != "./" && node != "../" && node != "." && node != "..") {
+    const pathUpTo = path.resolve("./"); //Get the relative path up to the node
+    const trueFile = trueCasePathSync(node, pathUpTo); //Get the case sensitive version of the absolute path
+    node = trueFile.replace(pathUpTo, "").slice(1); //Return case sensitive relative path
   }
 
-  storage.set(file, comment);
+  storage.set(node, comment);
   console.log(
-    '"' +
-      colors.cyan(comment) +
-      '" was applied to "' +
-      colors.cyan(file) +
-      '" successfully.'
+    `"${colors.cyan(comment)}" was applied to "${colors.cyan(
+      node
+    )}" successfully.`
   );
 };
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -14,8 +14,10 @@
 const pack = require("../package.json");
 const helpers = require("./helpers");
 const storage = require("./storage");
+const path = require("path");
 const fs = require("fs");
 const colors = require("colors/safe");
+const { trueCasePathSync } = require("true-case-path");
 
 var commands = module.exports;
 
@@ -67,7 +69,7 @@ commands.filteredList = function (dir) {
 };
 
 /** Adds or overwrites a comment to a file.
- * @param {File} file The name of the file to add a relevant `.comment`.
+ * @param {String} file The name of the file to add a relevant `.comment`.
  * @param {String} comment The comment to be written.
  */
 commands.set = function (file, comment) {
@@ -75,6 +77,12 @@ commands.set = function (file, comment) {
   if (!fs.existsSync(file)) {
     console.error("Please specify a valid directory or file.");
     return;
+  }
+
+  if (file != "./" && file != "../" && file != "." && file != "..") {
+    const pathUpTo = path.resolve("./");
+    const trueFile = trueCasePathSync(file, pathUpTo);
+    file = trueFile.replace(pathUpTo, "").replace("/", "");
   }
 
   storage.set(file, comment);

--- a/src/commands.js
+++ b/src/commands.js
@@ -83,6 +83,7 @@ commands.set = function (file, comment) {
     const pathUpTo = path.resolve("./");
     const trueFile = trueCasePathSync(file, pathUpTo);
     file = trueFile.replace(pathUpTo, "").replace("/", "");
+    file = trueFile.replace(pathUpTo, "").replace("\\", "");
   }
 
   storage.set(file, comment);


### PR DESCRIPTION
I identified an issue with case sensitivity - you could write a comment for a file in the wrong case (i.e. `README.md` could have a corresponding `ReAdMe.md.comment`) which would cause issues on Linux.
I added an additional dependency which can get the case-correct absolute file-path, then pattern matched away the absoluteness so we just have the relative filepath in case correct form.